### PR TITLE
change the header directory for the dvb includes

### DIFF
--- a/gpd-pocket-linux-jwrdegoede/PKGBUILD
+++ b/gpd-pocket-linux-jwrdegoede/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgbase=gpd-pocket-linux-jwrdegoede
 _srcname=linux-sunxi-master
-pkgver=4.15.0rc5.3bdb544
+pkgver=4.16.0rc2.bc6365f
 pkgrel=1
 arch=('x86_64')
 url='https://github.com/joshskidmore/gpd-pocket-arch-packages/tree/master/gpd-pocket-linux-jwrdegoede'
@@ -151,7 +151,7 @@ _package-headers() {
   install -Dt "${_builddir}/net/mac80211" -m644 net/mac80211/*.h
 
   # http://bugs.archlinux.org/task/9912
-  install -Dt "${_builddir}/drivers/media/dvb-core" -m644 drivers/media/dvb-core/*.h
+  install -Dt "${_builddir}/include/media" -m644 include/media/*.h
 
   # http://bugs.archlinux.org/task/13146
   install -Dt "${_builddir}/drivers/media/i2c" -m644 drivers/media/i2c/msp3400-driver.h


### PR DESCRIPTION
Somewhere in Kernel 4.16, the directory of the dvb header files changed to include/media, not that this is important for the gpd, but it made the buil fail. this is fixed now